### PR TITLE
Fix #29: Update example notebook

### DIFF
--- a/documentation/SleeveDecreases.ipynb
+++ b/documentation/SleeveDecreases.ipynb
@@ -59,8 +59,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyknit import GaugeSwatch\n",
-    "sweaterSwatch = GaugeSwatch(row_count=18, row_measure=3.25, stitch_count=24, stitch_measure=4, units=\"in\")"
+    "from pyknit import pyknit\n",
+    "sweaterSwatch = pyknit.GaugeSwatch(row_count=18, row_measure=3.25, stitch_count=24, stitch_measure=4, units=\"in\")"
    ]
   },
   {


### PR DESCRIPTION
## Description
After a recent update, the sleeve example was particularly affected and remained broke. The markdown doc for the example was fixed in PR #27 but the notebook received no fixes whatsoever. This PR updates the example in notebook and makes sure it isn't broke anymore.

Fixes Issue #29 
