### PR TITLE
Feature/logging (#38)

### DIFF
--- a/documentation/SleeveDecreases.ipynb
+++ b/documentation/SleeveDecreases.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyknit import pyknit\n",
+    "import pyknit\n",
     "sweaterSwatch = pyknit.GaugeSwatch(row_count=18, row_measure=3.25, stitch_count=24, stitch_measure=4, units=\"in\")"
    ]
   },
@@ -136,7 +136,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -150,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/pyknit/__init__.py
+++ b/pyknit/__init__.py
@@ -8,11 +8,7 @@ from .Hat import *
 
 logging_config_dict = dict(
     version=1,
-    formatters={
-        "simple": {
-            "format": """%(asctime)s | %(filename)s | %(lineno)d | %(levelname)s | %(message)s"""
-        }
-    },
+    formatters={"simple": {"format": """%(asctime)s | %(filename)s | %(lineno)d | %(levelname)s | %(message)s"""}},
     handlers={"console": {"class": "logging.StreamHandler", "formatter": "simple"}},
     root={"handlers": ["console"], "level": logging.DEBUG},
 )

--- a/pyknit/__init__.py
+++ b/pyknit/__init__.py
@@ -10,7 +10,7 @@ logging_config_dict = dict(
     version=1,
     formatters={
         "simple": {
-            "format": """%(asctime)s | %(name)-12s | %(levelname)-8s | %(message)s"""
+            "format": """%(asctime)s | %(filename)s | %(lineno)d | %(levelname)s | %(message)s"""
         }
     },
     handlers={"console": {"class": "logging.StreamHandler", "formatter": "simple"}},

--- a/pyknit/__init__.py
+++ b/pyknit/__init__.py
@@ -1,7 +1,20 @@
 # Copyright (C) 2021 Terri Oda
 # SPDX-License-Identifier: GPL-2.0-or-later
+import logging
 
-from .pyknit import *
 from .GaugeSwatch import *
 from .Chart import *
 from .Hat import *
+
+logging_config_dict = dict(
+    version=1,
+    formatters={
+        "simple": {
+            "format": """%(asctime)s | %(name)-12s | %(levelname)-8s | %(message)s"""
+        }
+    },
+    handlers={"console": {"class": "logging.StreamHandler", "formatter": "simple"}},
+    root={"handlers": ["console"], "level": logging.DEBUG},
+)
+
+from .pyknitter import *

--- a/pyknit/pi_shawl.py
+++ b/pyknit/pi_shawl.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 import argparse
+from logging.config import dictConfig
+
+from pyknit import logging_config_dict
 
 
 def total_rounds_for_pi_shawl(desired_radius: float, round_gauge: float) -> int:
@@ -31,4 +34,5 @@ def main():
 
 
 if __name__ == "__main__":
+    dictConfig(logging_config_dict)
     main()

--- a/pyknit/pyknitter.py
+++ b/pyknit/pyknitter.py
@@ -27,10 +27,10 @@ def increase_evenly(
 ) -> str:
     """ A function to figure out even spacing for increases """
 
-    if increase_number > starting_count :
-        logging.warning(
-            f"Error: Increase number ({increase_number}) is bigger than the starting count ({starting_count})"
-        )
+    if increase_number > starting_count:
+        logging.error(
+            f"Error: Increase number ({increase_number}) is bigger than the starting count ({starting_count})")
+        raise ValueError
 
     if not in_the_round:
         # It's increase+1 so that you don't have increases at either
@@ -75,10 +75,11 @@ def decrease_evenly(
     starting_count: PositiveInt, decrease_number: PositiveInt, in_the_round: bool = False
 ):
     """ A function to figure out spacing for decreases """
-    if decrease_number > starting_count :
-        logging.warning(
+    if decrease_number > starting_count:
+        logging.error(
             f"Error: Decrease number ({decrease_number}) is bigger than the starting count ({starting_count})"
         )
+        raise ValueError
 
 
 def sleeve_decreases(
@@ -93,13 +94,15 @@ def sleeve_decreases(
     # function.  We may want to combine them later.
 
     if starting_count < ending_count:
-        logging.warning(
+        logging.error(
             f"Error: No decreases needed, {starting_count} is already smaller than {ending_count}"
         )
+        raise ValueError
     elif starting_count == ending_count:
-        logging.warning(
+        logging.error(
             f"Error: No decreases needed, the starting count is the same as the ending count"
         )
+        raise ValueError
 
     # How many times are we doing the decrease row?
     number_of_decrease_rows = math.floor(

--- a/pyknit/pyknitter.py
+++ b/pyknit/pyknitter.py
@@ -8,6 +8,7 @@ patterns and more
 """
 
 import argparse
+import logging
 import math
 from logging.config import dictConfig
 from typing import Set
@@ -27,7 +28,7 @@ def increase_evenly(
     """ A function to figure out even spacing for increases """
 
     if increase_number > starting_count :
-        print(
+        logging.warning(
             f"Error: Increase number ({increase_number}) is bigger than the starting count ({starting_count})"
         )
 
@@ -75,7 +76,7 @@ def decrease_evenly(
 ):
     """ A function to figure out spacing for decreases """
     if decrease_number > starting_count :
-        print(
+        logging.warning(
             f"Error: Decrease number ({decrease_number}) is bigger than the starting count ({starting_count})"
         )
 
@@ -92,11 +93,11 @@ def sleeve_decreases(
     # function.  We may want to combine them later.
 
     if starting_count < ending_count:
-        print(
+        logging.warning(
             f"Error: No decreases needed, {starting_count} is already smaller than {ending_count}"
         )
     elif starting_count == ending_count:
-        print(
+        logging.warning(
             f"Error: No decreases needed, the starting count is the same as the ending count"
         )
 
@@ -106,10 +107,10 @@ def sleeve_decreases(
     )
     if ((starting_count - ending_count) % decrease_per_row) > 0:
         # TODO: we could probably do this math for people if we wanted
-        print(
+        logging.warning(
             f"Warning: desired decrease doesn't work exactly with a {decrease_per_row} decrease"
         )
-        print(
+        logging.warning(
             "Printing the closest alternative but you'll need to add decreases at the end"
         )
 
@@ -189,7 +190,7 @@ def raglan_increases(
 
 
 def main():
-    print(VERSION)
+    logging.info(f"VERSION = {VERSION}")
     desc = """
     This package is intended for use as a library inside jupyter notebook,
     so that you can see charts as they're parsed.

--- a/pyknit/pyknitter.py
+++ b/pyknit/pyknitter.py
@@ -9,9 +9,11 @@ patterns and more
 
 import argparse
 import math
+from logging.config import dictConfig
 from typing import Set
-from pyknit import GaugeSwatch, Chart
 from pydantic import validate_arguments, PositiveInt
+
+from pyknit import logging_config_dict, parse_written
 
 VERSION = "pyKnit 0.0.5a"
 
@@ -213,4 +215,5 @@ def main():
 
 
 if __name__ == "__main__":
+    dictConfig(logging_config_dict)
     main()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 
 setuptools.setup(
     name="pyknit",
-    version="0.0.5a",
+    version="0.0.6a",
     author="Terri Oda",
     author_email="terri@toybox.ca",
     description="A set of tools for knitters to create charts and eventually more.",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,5 @@
+from logging.config import dictConfig
+
+from pyknit import logging_config_dict
+
+dictConfig(logging_config_dict)

--- a/test/test_pyknit.py
+++ b/test/test_pyknit.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 #!python
+import logging
 
 import pytest
 import pyknit
@@ -54,3 +55,20 @@ def test_increase_evenly(starting_count, increase_number, in_the_round, expected
         pyknit.increase_evenly(starting_count, increase_number, in_the_round)
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    ("starting_count", "increase_number", "in_the_round", "expected"),
+    [
+        (3, 11, False, ValueError),
+        (7, 10, False, ValueError),
+        (3, 11, True, ValueError),
+        (5, 20, True, ValueError),
+        (5, 21, True, ValueError),
+        (5, 19, True, ValueError),
+    ],
+)
+def test_increase_evenly_error(starting_count, increase_number, in_the_round, expected):
+    with pytest.raises(expected):
+        logging.info(f"this should raise a valueError")
+        pyknit.increase_evenly(starting_count, increase_number, in_the_round)


### PR DESCRIPTION
I added a logging configuration to __init__.py
and raise ValueError after logging "Error:"

this implements #38 

Coincidentally, while doing that; I encountered some name collisions between pyknit  and pyknit.pyknit, so I renamed pyknit.py to pyknitter.py (I could not think of a better name for it, it just needs to be unique.)
I think this resolves #36

minimal usage:
you should really only configure the logger if your __name__ is __main__
```
from logging.config import dictConfig
from pyknit import logging_config_dict   
if __name__ == "__main__":
    dictConfig(logging_config_dict)
    main()
```    
example output:

![image](https://user-images.githubusercontent.com/26659886/165657581-f0fef89c-5a2f-4c78-af04-f7717cb67cbf.png)

![image](https://user-images.githubusercontent.com/26659886/165657628-f21eb7da-a8ed-47e1-93dd-2f0acb807ca1.png)

